### PR TITLE
Develop

### DIFF
--- a/.github/workflows/develop-build.yml
+++ b/.github/workflows/develop-build.yml
@@ -8,8 +8,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       
       - uses: oven-sh/setup-bun@v1
       
@@ -27,5 +32,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json
-          git commit -m "chore: bump build version [skip ci]"
+          git commit -m "chore: bump build version [skip ci]" || exit 0
           git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuration now loads at runtime instead of compile-time
 - Tool works without required-secrets.json (validation is optional)
 - Workflows now only trigger manually or on schedule (not on every push)
+- Fixed develop-build workflow permissions for automated version bumps
 
 ### Changed
 - Required secrets configuration is now optional

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrets-sync-cli",
-  "version": "1.0.1",
+  "version": "1.0.1-1",
   "description": "CLI tool for syncing environment secrets across environments with drift detection and GitHub Secrets integration",
   "type": "module",
   "bin": {


### PR DESCRIPTION
This pull request updates the automated build workflow and versioning to improve CI reliability and permissions for version bumps. The main changes include fixing workflow permissions, updating the workflow steps to handle authentication and commit failures gracefully, and bumping the package version.

**Workflow and Permissions Improvements:**

* Added `contents: write` permission and configured the `actions/checkout` step with a GitHub token in `.github/workflows/develop-build.yml` to enable automated version bumps.
* Updated the commit step in the workflow to avoid failing the job if there are no changes to commit, improving CI robustness.

**Versioning Updates:**

* Bumped the package version to `1.0.1-1` in `package.json` to reflect the workflow changes.

**Documentation:**

* Added a changelog entry noting the fix for develop-build workflow permissions for automated version bumps.