### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved error messages for missing or invalid configuration
 - All configuration warnings now use [CONFIG] prefix for easy filtering
 - Updated package name from `@dorsey-creative/secrets-sync` to `secrets-sync-cli`
+- Build versions now use date-based format (YYYYMMDD.X) that resets daily
 
 ### Added
 - Comprehensive test suite with 11 passing tests (5 unit + 5 integration)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrets-sync-cli",
-  "version": "1.0.1-1",
+  "version": "1.0.1-1-20251125.1",
   "description": "CLI tool for syncing environment secrets across environments with drift detection and GitHub Secrets integration",
   "type": "module",
   "bin": {

--- a/scripts/bump-build.sh
+++ b/scripts/bump-build.sh
@@ -7,19 +7,29 @@ set -e
 # Get current version from package.json
 CURRENT_VERSION=$(node -p "require('./package.json').version")
 
-# Extract base version (e.g., 1.0.0 from 1.0.0-18)
-BASE_VERSION=$(echo "$CURRENT_VERSION" | sed 's/-[0-9]*$//')
+# Extract base version (e.g., 1.0.0 from 1.0.0-20251124.1)
+BASE_VERSION=$(echo "$CURRENT_VERSION" | sed 's/-[0-9]*\.[0-9]*$//')
 
-# Extract build number or default to 0
-if [[ $CURRENT_VERSION =~ -([0-9]+)$ ]]; then
-  BUILD_NUM=${BASH_REMATCH[1]}
+# Get today's date in YYYYMMDD format
+TODAY=$(date +%Y%m%d)
+
+# Extract date and build number from current version if it exists
+if [[ $CURRENT_VERSION =~ -([0-9]{8})\.([0-9]+)$ ]]; then
+  CURRENT_DATE=${BASH_REMATCH[1]}
+  BUILD_NUM=${BASH_REMATCH[2]}
+  
+  # If same day, increment build number, otherwise reset to 1
+  if [ "$CURRENT_DATE" = "$TODAY" ]; then
+    NEW_BUILD_NUM=$((BUILD_NUM + 1))
+  else
+    NEW_BUILD_NUM=1
+  fi
 else
-  BUILD_NUM=0
+  # No date-based version yet, start at 1
+  NEW_BUILD_NUM=1
 fi
 
-# Increment build number
-NEW_BUILD_NUM=$((BUILD_NUM + 1))
-NEW_VERSION="${BASE_VERSION}-${NEW_BUILD_NUM}"
+NEW_VERSION="${BASE_VERSION}-${TODAY}.${NEW_BUILD_NUM}"
 
 # Update package.json
 npm version "$NEW_VERSION" --no-git-tag-version


### PR DESCRIPTION
This pull request introduces a new date-based build versioning scheme for the project, ensuring that build numbers reset daily and are easier to track. The changes update the version format throughout the codebase and improve the build bumping script to support this new convention.

Versioning improvements:

* Updated the version format in `package.json` to use `1.0.1-1-YYYYMMDD.X`, where the build number resets each day.
* Added a note in `CHANGELOG.md` about the new date-based build versioning scheme.

Build script enhancements:

* Refactored `scripts/bump-build.sh` to extract and increment the date-based build number, resetting it daily. The script now updates the version to match the new format.