### PR TITLE
fix(ci): add pre-flight checks and handle lockfile in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,45 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
       
+      - name: Pre-flight checks
+        run: |
+          echo "🔍 Running pre-flight checks..."
+          
+          # Check git status (excluding lockfile which will be committed separately)
+          CHANGES=$(git status --porcelain | grep -v "bun.lockb" || true)
+          if [[ -n "$CHANGES" ]]; then
+            echo "❌ Error: Git working directory is not clean"
+            echo "Uncommitted changes:"
+            echo "$CHANGES"
+            echo ""
+            echo "Please commit or stash changes before publishing:"
+            echo "  git add ."
+            echo "  git commit -m 'your message'"
+            exit 1
+          fi
+          
+          # Check we're on release branch
+          BRANCH=$(git branch --show-current)
+          if [[ "$BRANCH" != "release" ]]; then
+            echo "❌ Error: Must be on release branch (currently on: $BRANCH)"
+            exit 1
+          fi
+          
+          # Check CHANGELOG has been updated
+          if ! grep -q "## \[Unreleased\]" CHANGELOG.md; then
+            echo "⚠️  Warning: No [Unreleased] section in CHANGELOG.md"
+            echo "Consider adding release notes before publishing"
+          fi
+          
+          echo "✅ All pre-flight checks passed"
+      
+      - name: Commit lockfile if changed
+        run: |
+          if [[ -n $(git status --porcelain bun.lockb) ]]; then
+            git add bun.lockb
+            git commit -m "chore: update lockfile [skip ci]"
+          fi
+      
       - name: Bump version
         run: |
           # Strip build suffix if present (e.g., 1.0.2-20251124.1 -> 1.0.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Error messages show exact paths, reasons, and copy-pasteable fix commands (#5)
 - README simplified and restructured: moved development details to CONTRIBUTING.md, detailed troubleshooting to docs/ (#14)
 
+### Fixed
+
+- CI publish workflow now builds before testing to ensure dist/ artifacts exist
+- CI publish workflow includes pre-flight checks with clear error messages
+- CI publish workflow auto-commits lockfile changes to prevent version bump failures
+
 ## [1.0.6] - 2025-11-24
 
 ### Fixed


### PR DESCRIPTION
Adds validation before version bump to catch issues early and handles bun.lockb updates that were causing "Git working directory not clean" errors.

Changes:
- Add pre-flight checks step that validates git status, branch, and CHANGELOG
- Exclude bun.lockb from dirty check (it's auto-updated by bun install)
- Auto-commit lockfile changes before version bump if needed
- Provide clear error messages with actionable fix commands

This prevents confusing npm version errors and ensures the workflow fails early with helpful messages when there are uncommitted changes.