### PR TITLE
fix(ci): fetch full git history for correct version detection

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+          fetch-tags: true
       
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI publish workflow now builds before testing to ensure dist/ artifacts exist
 - CI publish workflow includes pre-flight checks with clear error messages
 - CI publish workflow auto-commits lockfile changes to prevent version bump failures
+- CI publish workflow fetches latest tags to ensure correct version bump
 
 ## [1.0.6] - 2025-11-24
 


### PR DESCRIPTION
Fixes version bump using stale cached version instead of current version. The workflow was showing v1.0.6 when the actual version was 1.0.6-20251126.3, causing incorrect version bumps.

Changes:
- Add fetch-depth: 0 to checkout full git history
- Add fetch-tags: true to fetch all version tags

This ensures npm version correctly detects the current version from package.json and git tags, allowing proper version bumps (e.g., 1.0.6-20251126.3 -> 1.1.0).