### PR TITLE
11 add secret values scrubbing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,42 +49,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
       
-      - name: Pre-flight checks
-        run: |
-          echo "🔍 Running pre-flight checks..."
-          
-          # Check git status (excluding lockfile which will be committed separately)
-          CHANGES=$(git status --porcelain | grep -v "bun.lockb" || true)
-          if [[ -n "$CHANGES" ]]; then
-            echo "❌ Error: Git working directory is not clean"
-            echo "Uncommitted changes:"
-            echo "$CHANGES"
-            echo ""
-            echo "Please commit or stash changes before publishing:"
-            echo "  git add ."
-            echo "  git commit -m 'your message'"
-            exit 1
-          fi
-          
-          # Check we're on release branch
-          BRANCH=$(git branch --show-current)
-          if [[ "$BRANCH" != "release" ]]; then
-            echo "❌ Error: Must be on release branch (currently on: $BRANCH)"
-            exit 1
-          fi
-          
-          # Check CHANGELOG has been updated
-          if ! grep -q "## \[Unreleased\]" CHANGELOG.md; then
-            echo "⚠️  Warning: No [Unreleased] section in CHANGELOG.md"
-            echo "Consider adding release notes before publishing"
-          fi
-          
-          echo "✅ All pre-flight checks passed"
-      
       - name: Commit lockfile if changed
         run: |
-          if [[ -n $(git status --porcelain bun.lockb) ]]; then
-            git add bun.lockb
+          if [[ -n $(git status --porcelain bun.lock) ]]; then
+            git add bun.lock
             git commit -m "chore: update lockfile [skip ci]"
           fi
       

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -1,0 +1,45 @@
+name: Release Pre-flight Checks
+
+on:
+  pull_request:
+    branches:
+      - release
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Pre-flight checks
+        run: |
+          echo "🔍 Running pre-flight checks for release..."
+          
+          # Check git status (should be clean for PR)
+          if [[ -n $(git status --porcelain) ]]; then
+            echo "❌ Error: Git working directory is not clean"
+            echo "Uncommitted changes:"
+            git status --short
+            echo ""
+            echo "Please commit all changes before creating PR to release"
+            exit 1
+          fi
+          
+          # Check CHANGELOG has been updated
+          if ! grep -q "## \[Unreleased\]" CHANGELOG.md; then
+            echo "⚠️  Warning: No [Unreleased] section in CHANGELOG.md"
+            echo "Consider adding release notes before merging to release"
+          fi
+          
+          # Check version in package.json
+          VERSION=$(node -p "require('./package.json').version")
+          echo "📦 Current version: $VERSION"
+          
+          if [[ $VERSION == *"-"* ]]; then
+            echo "✅ Version has build suffix (will be stripped during publish)"
+          fi
+          
+          echo "✅ All pre-flight checks passed"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - CI publish workflow now builds before testing to ensure dist/ artifacts exist
-- CI publish workflow includes pre-flight checks with clear error messages
-- CI publish workflow auto-commits lockfile changes to prevent version bump failures
+- CI publish workflow fetches full git history for correct version detection
+- CI publish workflow auto-commits bun.lock changes to prevent version bump failures
+- Added separate pre-flight checks workflow for PRs to release branch
 - CI publish workflow fetches latest tags to ensure correct version bump
 
 ## [1.0.6] - 2025-11-24


### PR DESCRIPTION
This pull request refactors the CI pre-flight checks for publishing and release workflows. The main change is moving pre-flight checks out of the publish workflow into a dedicated workflow that runs on pull requests to the release branch. It also updates how lockfile changes are handled and improves release process reliability.

**CI workflow improvements:**

* Added a new `.github/workflows/release-preflight.yml` workflow to run pre-flight checks automatically on pull requests to the `release` branch, ensuring the working directory is clean, the changelog is updated, and the package version is checked before merging.
* Removed pre-flight checks from `.github/workflows/publish.yml`, streamlining the publish workflow to focus only on publishing and lockfile handling.

**Lockfile and changelog handling:**

* Updated the publish workflow to commit changes to `bun.lock` instead of `bun.lockb`, aligning with current lockfile naming conventions.
* Updated the changelog to reflect the new workflow structure, the lockfile handling change, and the addition of the release pre-flight workflow.