### PR TITLE
Develop

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,15 @@ jobs:
       
       - name: Install dependencies
         run: bun install
-      
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version (no tag yet)
+        run: npm version ${{ inputs.version }} --no-git-tag-version
+
       - name: Build
         run: bun run build
       
@@ -43,32 +51,6 @@ jobs:
         run: bun test
         env:
           SKIP_DEPENDENCY_CHECK: '1'
-      
-      - name: Configure Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-      
-      - name: Commit lockfile if changed
-        run: |
-          if [[ -n $(git status --porcelain bun.lock) ]]; then
-            git add bun.lock
-            git commit -m "chore: update lockfile [skip ci]"
-            git push origin release
-          fi
-      
-      - name: Bump version
-        run: |
-          # Strip build suffix if present (e.g., 1.0.2-20251124.1 -> 1.0.2)
-          CURRENT=$(node -p "require('./package.json').version")
-          BASE=$(echo "$CURRENT" | sed 's/-[0-9]*\.[0-9]*$//')
-          if [ "$CURRENT" != "$BASE" ]; then
-            npm version "$BASE" --no-git-tag-version
-          fi
-          npm version ${{ inputs.version }} -m "chore: release v%s [skip ci]"
-      
-      - name: Push changes
-        run: git push origin release --follow-tags
       
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -80,3 +62,15 @@ jobs:
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Commit and tag release
+        run: |
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          git add package.json bun.lock
+          if [[ -n $(git status --porcelain) ]]; then
+            git commit -m "chore: release v${NEW_VERSION} [skip ci]"
+            git tag "v${NEW_VERSION}"
+            git push origin release --tags
+          else
+            echo "No changes to commit."
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,6 +54,7 @@ jobs:
           if [[ -n $(git status --porcelain bun.lock) ]]; then
             git add bun.lock
             git commit -m "chore: update lockfile [skip ci]"
+            git push origin release
           fi
       
       - name: Bump version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,11 +41,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- CI publish workflow now builds before testing to ensure dist/ artifacts exist
+- CI publish workflow now versions before build to ensure correct version in dist/ artifacts
+- CI publish workflow commits and tags after npm publish for atomic releases
+- CI publish workflow builds before testing to ensure dist/ artifacts exist
 - CI publish workflow fetches full git history for correct version detection
-- CI publish workflow auto-commits bun.lock changes to prevent version bump failures
 - Added separate pre-flight checks workflow for PRs to release branch
-- CI publish workflow fetches latest tags to ensure correct version bump
 
 ## [1.0.6] - 2025-11-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
 ## [1.1.0] - 2025-11-26
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrets-sync-cli",
-  "version": "1.0.6-20251126.9",
+  "version": "1.0.6-20251126.10",
   "description": "CLI tool for syncing environment secrets across environments with drift detection and GitHub Secrets integration",
   "type": "module",
   "bin": {


### PR DESCRIPTION
This pull request updates the CI publish workflow to improve the reliability and atomicity of releases, and includes a version bump for the package. The workflow now ensures the correct version is present in build artifacts, commits and tags releases after publishing, and maintains proper build/test order.

**CI workflow improvements:**

* The publish workflow now bumps the package version before building, ensuring that the correct version is present in the built `dist/` artifacts.
* After publishing to npm, the workflow now commits and tags the release atomically, then pushes both the commit and tags to the remote repository.
* The workflow order is adjusted to build before running tests, ensuring that tests run against the latest build artifacts.

**Version updates:**

* The `package.json` version is bumped from `1.0.6-20251126.9` to `1.0.6-20251126.10`.

**Documentation:**

* The changelog is updated to reflect the workflow changes and clarify the release process. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL8-L9) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL46-L50)