### PR TITLE
ci(publish): add post-release sync job to create PR for dev

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,3 +74,38 @@ jobs:
           else
             echo "No changes to commit."
           fi
+
+  sync-to-dev:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: release
+          fetch-depth: 0
+      
+      - name: Create PR to dev
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          BRANCH_NAME="sync/release-v${NEW_VERSION}-to-dev"
+          
+          git checkout -b "${BRANCH_NAME}"
+          git push origin "${BRANCH_NAME}"
+          
+          gh pr create \
+            --base dev \
+            --head "${BRANCH_NAME}" \
+            --title "chore: sync release v${NEW_VERSION} to dev" \
+            --body "Automated PR to sync release v${NEW_VERSION} back to dev branch.
+
+          **Changes:**
+          - Version bump to ${NEW_VERSION}
+          - Release tag created
+
+          This PR should be merged to keep dev in sync with release."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Publish workflow now automatically creates PR to sync release changes back to dev branch
+
 ## [1.1.1] - 2025-11-26
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrets-sync-cli",
-  "version": "1.1.0-20251127.2",
+  "version": "1.1.1-20251127.2",
   "description": "CLI tool for syncing environment secrets across environments with drift detection and GitHub Secrets integration",
   "type": "module",
   "bin": {


### PR DESCRIPTION
After successful npm publish, automatically create a PR to sync release changes back to dev branch:

- New sync-to-dev job runs after publish completes
- Creates branch sync/release-vX.Y.Z-to-dev from release
- Opens PR to dev with version bump and release tag
- Uses GitHub CLI with proper permissions (contents, pull-requests)

Ensures dev branch stays in sync with production releases without manual intervention.

Scope: CI/CD automation for release workflow