### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.2.0] - 2025-11-30
+## [1.2.1] - 2025-12-01
+
+### Fixed
+
+- CLI now works with Node.js runtime
+- GitHub CLI integration no longer fails with runtime errors
+
+## [1.2.0] - 2025-11-30 [DEPRECATED]
+
+**This version is broken. Use 1.2.1 or later.**
 
 ### Added
 
@@ -29,7 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Version and help commands now exit early without unnecessary warnings
 
-## [1.1.1] - 2025-11-26
+## [1.1.1] - 2025-11-26 [DEPRECATED]
+
+**This version is broken. Use 1.2.1 or later.**
 
 ### Fixed
 
@@ -41,7 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Example directory for local testing (`bun run setup:example`)
 - Pre-commit hook to validate version format
 
-## [1.1.0] - 2025-11-26
+## [1.1.0] - 2025-11-26 [DEPRECATED]
+
+**This version is broken. Use 1.2.1 or later.**
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ Sync `.env` files and GitHub Actions secrets with lightweight drift detection an
 - Preview every change with dry-run and optional confirmation gates.
 
 ## Prerequisites
-- Node 18+ runtime. Development and tests use Bun (`bun install`, `bun test`).
-- GitHub CLI (`gh`) authenticated if you want to sync to GitHub Secrets.
-- Env files live in `config/env` by default (configurable via `--dir`).
+- Node.js 18+ (for running the CLI)
+- Bun runtime (for development - install from [bun.sh](https://bun.sh))
+- GitHub CLI (`gh`) authenticated if you want to sync to GitHub Secrets
+- Env files live in `config/env` by default (configurable via `--dir`)
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrets-sync-cli",
-  "version": "1.2.0-20251201.1",
+  "version": "1.2.0-20251201.2",
   "description": "CLI tool for syncing environment secrets across environments with drift detection and GitHub Secrets integration",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrets-sync-cli",
-  "version": "1.2.0",
+  "version": "1.2.0-20251201.1",
   "description": "CLI tool for syncing environment secrets across environments with drift detection and GitHub Secrets integration",
   "type": "module",
   "bin": {

--- a/tests/integration/filePermissions.test.ts
+++ b/tests/integration/filePermissions.test.ts
@@ -8,6 +8,17 @@ const CONFIG_DIR = path.join(TEST_DIR, "config", "env");
 describe("File Permission Integration Tests", () => {
   beforeEach(() => {
     if (fs.existsSync(TEST_DIR)) {
+      // Reset permissions before cleanup
+      try {
+        fs.chmodSync(CONFIG_DIR, 0o755);
+        const files = fs.readdirSync(CONFIG_DIR);
+        files.forEach(file => {
+          const filePath = path.join(CONFIG_DIR, file);
+          try {
+            fs.chmodSync(filePath, 0o644);
+          } catch {}
+        });
+      } catch {}
       fs.rmSync(TEST_DIR, { recursive: true, force: true });
     }
     fs.mkdirSync(CONFIG_DIR, { recursive: true });


### PR DESCRIPTION
This pull request updates the CLI to work reliably with the Node.js runtime and fixes integration issues with the GitHub CLI. The main changes involve replacing all usages of Bun-specific APIs with Node.js equivalents, updating documentation and versioning, and marking previous broken releases as deprecated.

**Runtime compatibility and CLI reliability:**

* Replaced all `Bun.spawnSync` calls with Node.js `spawnSync` in `src/secrets-sync.ts` to ensure the CLI works with the Node.js runtime instead of Bun. This affects secret management, backup, and cleanup operations. [[1]](diffhunk://#diff-a0b92d1745c048183373d8d88ef4da26215d108f0b33288d2fec1fb5cec9a699R20) [[2]](diffhunk://#diff-a0b92d1745c048183373d8d88ef4da26215d108f0b33288d2fec1fb5cec9a699L661-R667) [[3]](diffhunk://#diff-a0b92d1745c048183373d8d88ef4da26215d108f0b33288d2fec1fb5cec9a699L679-R691) [[4]](diffhunk://#diff-a0b92d1745c048183373d8d88ef4da26215d108f0b33288d2fec1fb5cec9a699L980-R981) [[5]](diffhunk://#diff-a0b92d1745c048183373d8d88ef4da26215d108f0b33288d2fec1fb5cec9a699L1007-R1008)
* Updated the prerequisites in `README.md` to clarify that Node.js 18+ is required for running the CLI, while Bun is only needed for development.

**Versioning and changelog updates:**

* Updated `package.json` to use a pre-release version format (`1.2.0-20251201.2`) to reflect the new release.
* Marked previous releases (`1.1.0`, `1.1.1`, `1.2.0`) as deprecated in `CHANGELOG.md`, with a note to use `1.2.1` or later due to runtime issues. Added a "Fixed" section for `1.2.1` describing the Node.js and GitHub CLI fixes. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL10-R19) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL32-R43) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL44-R57)

**Test reliability:**

* Improved integration test setup in `tests/integration/filePermissions.test.ts` by resetting file and directory permissions before cleanup to avoid permission-related test failures.