### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Post-release workflow now merges to `develop` before creating version branch
 - Version-specific branches (e.g., `1.2.2-develop`) created from merged `develop` state
+- Removed test coverage failure from the CI workflow
 
 ### Added
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,3 @@
 [test]
 timeout = 5000
 coverage = true
-coverageThreshold = 80

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrets-sync-cli",
-  "version": "1.2.1-20251201.2",
+  "version": "1.2.1-20251201.3",
   "description": "CLI tool for syncing environment secrets across environments with drift detection and GitHub Secrets integration",
   "type": "module",
   "bin": {


### PR DESCRIPTION
This pull request mainly removes the test coverage failure requirement from the CI workflow and configuration. It also includes a version bump for the package. These changes help streamline the development process by allowing tests to pass even if coverage falls below a previously set threshold.

**Continuous Integration & Test Coverage:**
* Removed the test coverage failure check from the CI workflow, so builds will no longer fail if coverage drops below a threshold. (`CHANGELOG.md`)
* Removed the `coverageThreshold` setting from the test configuration in `bunfig.toml`.

**Release Management:**
* Bumped the package version from `1.2.1-20251201.2` to `1.2.1-20251201.3` in `package.json`.