### PR TITLE
Develop

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,6 +106,15 @@ jobs:
           git fetch origin develop
           git checkout develop
           git merge origin/release --no-edit
+          
+          # Convert version to prerelease format for develop branch
+          RELEASE_VERSION=$(node -p "require('./package.json').version")
+          DATESTAMP=$(date +%Y%m%d)
+          PRERELEASE_VERSION="${RELEASE_VERSION}-${DATESTAMP}.1"
+          
+          npm version $PRERELEASE_VERSION --no-git-tag-version
+          git add package.json bun.lock
+          git commit -m "chore: convert to prerelease version ${PRERELEASE_VERSION} [skip ci]"
           git push origin develop
       
       - name: Create version-specific develop branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.3] - 2025-12-01
+
+### Changed
+
+- Reduced console output: informational logs now require `--verbose` flag
+- Production runs show only warnings and errors
+
 ## [1.2.2] - 2025-12-01
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrets-sync-cli",
-  "version": "1.2.2",
+  "version": "1.2.2-20251201.1",
   "description": "CLI tool for syncing environment secrets across environments with drift detection and GitHub Secrets integration",
   "type": "module",
   "bin": {

--- a/src/secrets-sync.ts
+++ b/src/secrets-sync.ts
@@ -1261,7 +1261,7 @@ async function main() {
     logInfo('MOCK MODE enabled via SECRETS_SYNC_MOCK=1 — using in-memory mock adapter');
     adapter = new MockGitHubSecretsAdapter(mockExisting);
   } else {
-    logInfo('Using gh CLI adapter to read existing GitHub secrets');
+    logDebug('Using gh CLI adapter to read existing GitHub secrets');
     adapter = new GhCliSecretsAdapter();
   }
 
@@ -1269,7 +1269,7 @@ async function main() {
   const manifest = loadManifest(dir);
   const manifestCount = Object.keys(manifest).length;
   if (manifestCount > 0) {
-    logInfo(`Loaded manifest with ${manifestCount} secret(s) for diff comparison`);
+    logDebug(`Loaded manifest with ${manifestCount} secret(s) for diff comparison`);
   }
 
   const { desired, sourceBySecret } = buildDesiredWithSources(envSummaries);
@@ -1308,7 +1308,7 @@ async function main() {
     logInfo('Dry-run mode: no prompts, no mutations.');
     printAuditSummary(plan, { mode: 'dry-run', skippedFromConfig: allSkipped });
     console.log('');
-    logSuccess('Initialization complete: files scanned, production resolved, dotenv parsed, drift warnings emitted.');
+    logDebug('Initialization complete: files scanned, production resolved, dotenv parsed, drift warnings emitted.');
     return;
   }
 
@@ -1440,7 +1440,7 @@ async function main() {
   });
 
   console.log('');
-  logSuccess('Initialization complete: files scanned, production resolved, dotenv parsed, drift warnings emitted.');
+  logDebug('Initialization complete: files scanned, production resolved, dotenv parsed, drift warnings emitted.');
   
   // Create timestamp file for pre-push hook (only on successful real sync)
   if (!flags.dryRun && approved.length > 0 && failures.length === 0) {


### PR DESCRIPTION
This pull request introduces a new prerelease versioning workflow for the `develop` branch and reduces console output in production runs to improve clarity and signal-to-noise ratio. It also updates the changelog to reflect these changes and refactors logging in `src/secrets-sync.ts` to require the `--verbose` flag for informational logs.

**Release and Versioning Improvements:**
* Updated the GitHub Actions workflow in `.github/workflows/publish.yml` to automatically convert the version to a prerelease format (e.g., `1.2.3-YYYYMMDD.1`) when merging into the `develop` branch. This ensures that prerelease versions are clearly identified and avoids accidental release of production versions from `develop`.

**Logging and Output Changes:**
* Changed several `logInfo` and `logSuccess` calls in `src/secrets-sync.ts` to `logDebug`, so that informational logs only appear when the `--verbose` flag is used. This reduces console output during normal production runs, displaying only warnings and errors by default. [[1]](diffhunk://#diff-a0b92d1745c048183373d8d88ef4da26215d108f0b33288d2fec1fb5cec9a699L1264-R1272) [[2]](diffhunk://#diff-a0b92d1745c048183373d8d88ef4da26215d108f0b33288d2fec1fb5cec9a699L1311-R1311) [[3]](diffhunk://#diff-a0b92d1745c048183373d8d88ef4da26215d108f0b33288d2fec1fb5cec9a699L1443-R1443)

**Documentation Updates:**
* Updated `CHANGELOG.md` to document the reduced console output and the requirement for the `--verbose` flag to see informational logs. Also added a new unreleased version entry for `1.2.3`.