### PR TITLE
[codex] resolve OSV dependency findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `timeout`: Configure operation timeout in milliseconds
     - `mock`: Enable mock mode for testing
 
+### Fixed
+
+- Updated vulnerable dependency resolutions reported by OSV (`yaml` and transitive `picomatch`).
+
 ## [1.2.5] - 2025-12-11
 
 ### Fixed

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "secrets-sync-cli",
       "dependencies": {
         "lru-cache": "^11.2.2",
-        "yaml": "^2.8.1",
+        "yaml": "^2.9.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -14,6 +14,9 @@
         "jscpd": "^4.0.5",
       },
     },
+  },
+  "overrides": {
+    "picomatch": "2.3.2",
   },
   "packages": {
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
@@ -188,7 +191,7 @@
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
-    "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+    "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "promise": ["promise@7.3.1", "", { "dependencies": { "asap": "~2.0.3" } }, "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="],
 
@@ -262,7 +265,7 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "yaml": ["yaml@2.8.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw=="],
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "node-sarif-builder/fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
   }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
   },
   "dependencies": {
     "lru-cache": "^11.2.2",
-    "yaml": "^2.8.1"
+    "yaml": "^2.9.0"
+  },
+  "overrides": {
+    "picomatch": "2.3.2"
   }
 }


### PR DESCRIPTION
## Summary

Resolves the OSV findings reported after adding the security pipeline:

- Updates `yaml` from `^2.8.1` to `^2.9.0`
- Adds a Bun/npm override for transitive `picomatch` to `2.3.2`
- Regenerates `bun.lock`
- Adds an Unreleased changelog note

## Validation

- `docker run --rm --entrypoint osv-scanner -v "$PWD:/github/workspace" -w /github/workspace ghcr.io/google/osv-scanner-action:v2.3.8 scan source -r ./` passed: `No issues found`
- `SKIP_DEPENDENCY_CHECK=1 bun test` passed: 310 pass, 0 fail